### PR TITLE
Ignore multiple references of components / version pattern change

### DIFF
--- a/bootstrap-configurator.js
+++ b/bootstrap-configurator.js
@@ -17,6 +17,9 @@ var getLessContent = function (filename) {
   });
 };
 
+var lessProcessed = [];
+var jsProcessed = [];
+
 var handler = function (compileStep, isLiterate) {
   var jsonPath = compileStep._fullInputPath;
 
@@ -79,13 +82,19 @@ var handler = function (compileStep, isLiterate) {
   
   // add javascripts
   for (var jsPath in js) {
-    var file = getAsset(jsPath);
-    compileStep.addJavaScript({
-      path: jsPath,
-      data: file,
-      sourcePath: jsPath,
-      bare: true // they are already wrapped (tiny optimisation)
-    });
+    if(typeof jsProcessed[compileStep.arch] === "undefined") {
+      jsProcessed[compileStep.arch] = [];
+    }
+    if(_.indexOf(jsProcessed[compileStep.arch], jsPath) === -1) {
+      jsProcessed[compileStep.arch].push(jsPath);
+      var file = getAsset(jsPath);
+      compileStep.addJavaScript({
+        path: jsPath,
+        data: file,
+        sourcePath: jsPath,
+        bare: true // they are already wrapped (tiny optimisation)
+      });
+    }
   }
   
   // filenames
@@ -128,7 +137,13 @@ var handler = function (compileStep, isLiterate) {
     '@icon-font-path: "/packages/nemo64_bootstrap-data/bootstrap/fonts/";'
   ];
   _.each(less, function (lessPath) {
-    bootstrapContent.push(getLessContent('' + lessPath));
+    if(typeof lessProcessed[compileStep.arch] === "undefined") {
+      lessProcessed[compileStep.arch] = [];
+    }
+    if(_.indexOf(lessProcessed[compileStep.arch], lessPath) === -1) {
+      lessProcessed[compileStep.arch].push(lessPath)
+      bootstrapContent.push(getLessContent('' + lessPath));
+    }
   });
   createLessFile(outputLessFile, bootstrapContent);
   

--- a/package.js
+++ b/package.js
@@ -1,10 +1,9 @@
 Package.describe({
   name: "nemo64:bootstrap",
   summary: "Highly configurable bootstrap integration.",
-  version: "3.2.3",
+  version: "3.2.0_1",
   git: "https://github.com/Nemo64/meteor-bootstrap"
 });
-
 
 Package._transitional_registerBuildPlugin({
   name: 'bootstrap-configurator',

--- a/versions.json
+++ b/versions.json
@@ -6,7 +6,7 @@
     ],
     [
       "meteor",
-      "1.1.0"
+      "1.1.1"
     ],
     [
       "nemo64:bootstrap-data",
@@ -22,11 +22,11 @@
       "bootstrap-configurator",
       {
         "underscore": "1.0.0",
-        "meteor": "1.1.0",
+        "meteor": "1.1.1",
         "nemo64:bootstrap-data": "3.2.0-rc2"
       }
     ]
   ],
-  "toolVersion": "meteor-tool@1.0.31",
+  "toolVersion": "meteor-tool@1.0.33",
   "format": "1.0"
 }


### PR DESCRIPTION
- In case a bootstrap component is references multiple times within multiple *bootstrap.json files, it's still only added once. #8
- Change version pattern to better see which version of bootstrap is shipped. #9 (I hope it's possible to publish it with this lowered version number)
