### PR TITLE
Generating CSS instead of Less file

### DIFF
--- a/.npm/plugin/bootstrap-configurator/.gitignore
+++ b/.npm/plugin/bootstrap-configurator/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/plugin/bootstrap-configurator/README
+++ b/.npm/plugin/bootstrap-configurator/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/plugin/bootstrap-configurator/npm-shrinkwrap.json
+++ b/.npm/plugin/bootstrap-configurator/npm-shrinkwrap.json
@@ -1,0 +1,162 @@
+{
+  "dependencies": {
+    "less": {
+      "version": "2.2.0",
+      "dependencies": {
+        "graceful-fs": {
+          "version": "3.0.5"
+        },
+        "mime": {
+          "version": "1.2.11"
+        },
+        "request": {
+          "version": "2.51.0",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.3",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1"
+                    },
+                    "isarray": {
+                      "version": "0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31"
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.8.0"
+            },
+            "forever-agent": {
+              "version": "0.5.2"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.0"
+                },
+                "mime-types": {
+                  "version": "2.0.7",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.5.0"
+                    }
+                  }
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0"
+            },
+            "mime-types": {
+              "version": "1.0.2"
+            },
+            "node-uuid": {
+              "version": "1.4.2"
+            },
+            "qs": {
+              "version": "2.3.3"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5"
+                },
+                "asn1": {
+                  "version": "0.1.11"
+                },
+                "ctype": {
+                  "version": "0.5.3"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.5.0"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1"
+                },
+                "boom": {
+                  "version": "0.4.2"
+                },
+                "cryptiles": {
+                  "version": "0.2.2"
+                },
+                "sntp": {
+                  "version": "0.2.4"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0"
+            },
+            "stringstream": {
+              "version": "0.0.4"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0"
+            }
+          }
+        },
+        "promise": {
+          "version": "6.1.0",
+          "dependencies": {
+            "asap": {
+              "version": "1.0.0"
+            }
+          }
+        },
+        "image-size": {
+          "version": "0.3.5"
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ input {
 ```
 This is because there are many pseudo-classes that `.form-control` has associated with it, but the standard `extend` only finds exact matches. To match those pseudo-classes as well, you need to use the `all` keyword.
 
+### A quirk in `extend`ing
+Using `extend` to include the Bootstrap styles in your stylesheets copies in the styles rather than [adding the selector to the properties you wish to use](http://lesscss.org/features/#extend-feature-reducing-css-size). This is a limitation of Meteor since all of the Less files are compiled independently. You can get around this if you have one file that has `@import (reference) custom.bootstrap.import.less` first and then explicitly imports every single stylesheet that will depend on Bootstrap (which will all need to end in `.import.less`). All of those stylesheets will then be compiled in the same step.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,129 @@
-Bootstrap for meteor
-====================
-
-This package integrates bootstrap into meteor and lets you configure what parts you need.
-
-How to install
---------------
+# Semantic Bootstrap for Meteor
+This package integrates Bootstrap into Meteor and lets you configure what parts you need. In addition, it's built so that you can put your Bootstrap in your Less stylesheets instead of your HTML. It's kind of like an automatic Bootstrap theme generator.
 
 
+## Installation
 
 1. execute `meteor add nemo64:bootstrap less`
 2. create an empty `custom.bootstrap.json` file somewhere in your project. (`/client/lib/custom.bootstrap.json` for example)
 3. start meteor and then edit the file you just created (see [custom.bootstrap.json](#custom.bootstrap.json)).
 4. (optional) edit `custom.bootstrap.import.less` which now appeared next to the json file
 
-custom.bootstrap.json
----------------------
-This file is to configure which bootstrap parts you need in your project. Set those you like to `true`!
+## The Generated Files
+### custom.bootstrap.json
+
+This file configures which Bootstrap modules will be included in the project. These settings control whether the Stylesheet and Javascript (if there is any for the module) is included in the application. Set those you like to `true`!
+
 If the file is empty, it will be filled for with the following content:
+
 ```JSON
-{"modules": {
-  "normalize":            true,
-  "print":                false,
+{ 
+  "modules": {
+    "normalize":            true,
+    "print":                false,
 
-  "scaffolding":          false,
-  "type":                 false,
-  "code":                 false,
-  "grid":                 false,
-  "tables":               false,
-  "forms":                false,
-  "buttons":              false,
+    "scaffolding":          false,
+    "type":                 false,
+    "code":                 false,
+    "grid":                 false,
+    "tables":               false,
+    "forms":                false,
+    "buttons":              false,
 
-  "glyphicons":           false,
-  "button-groups":        false,
-  "input-groups":         false,
-  "navs":                 false,
-  "navbar":               false,
-  "breadcrumbs":          false,
-  "pagination":           false,
-  "pager":                false,
-  "labels":               false,
-  "badges":               false,
-  "jumbotron":            false,
-  "thumbnails":           false,
-  "alerts":               false,
-  "progress-bars":        false,
-  "media":                false,
-  "list-group":           false,
-  "panels":               false,
-  "wells":                false,
-  "close":                false,
+    "glyphicons":           false,
+    "button-groups":        false,
+    "input-groups":         false,
+    "navs":                 false,
+    "navbar":               false,
+    "breadcrumbs":          false,
+    "pagination":           false,
+    "pager":                false,
+    "labels":               false,
+    "badges":               false,
+    "jumbotron":            false,
+    "thumbnails":           false,
+    "alerts":               false,
+    "progress-bars":        false,
+    "media":                false,
+    "list-group":           false,
+    "panels":               false,
+    "wells":                false,
+    "close":                false,
 
-  "component-animations": false,
-  "dropdowns":            false,
-  "modals":               false,
-  "tooltip":              false,
-  "popovers":             false,
-  "carousel":             false,
-  
-  "affix":                false,
-  "alert":                false,
-  "button":               false,
-  "collapse":             false,
-  "scrollspy":            false,
-  "tab":                  false,
-  "transition":           false,
+    "component-animations": false,
+    "dropdowns":            false,
+    "modals":               false,
+    "tooltip":              false,
+    "popovers":             false,
+    "carousel":             false,
+    
+    "affix":                false,
+    "alert":                false,
+    "button":               false,
+    "collapse":             false,
+    "scrollspy":            false,
+    "tab":                  false,
+    "transition":           false,
 
-  "utilities":            false,
-  "responsive-utilities": false
-}}
+    "utilities":            false,
+    "responsive-utilities": false
+  }
+}
 ```
 
-License
--------
+### custom.bootstrap.variables.import.less
+This file is auto generated once and is then never overwritten. It includes the variables upon which Bootstrap is built. Use these your own stylesheets with `@import "path/in/your/project/custom.bootstrap.variables.import.less"`
+
+### custom.bootstrap.mixins.import.less
+This file is auto generated and any changes will be overwritten. It includes the Less mixins that Bootstrap uses to compile its CSS. Use these your own stylesheets with `@import "path/in/your/project/custom.bootstrap.mixins.import.less"`
+
+### custom.bootstrap.import.less
+This is the compiled Bootstrap CSS, built according to the specified modules and variables in `custom.bootstrap.variables.import.less`. Although it has a `.import.less` suffix, it's just vanilla CSS. The suffix is there so you can explicitly control when it is loaded in. Reference these styles in your own stylesheet with `@import (reference) "path/in/your/project/custom.bootstrap.import.less"`.
+
+Be sure to include the `(reference)` keyword when importing so that the styles are processed but not copied into the stylesheet (unless you want them copied). If you're including normalize.css or using Bootstrap classes in your HTML you'll want to `import` without the `(reference)` one time somewhere in your application.
+
+## Recommended Usage
+Instead of putting Bootstrap in your markup put it in your stylesheets! HTML is where you say what things are, not how they should look. This means that instead of doing something like
+
+```html
+<button id="myBtn" class="btn btn-default btn-primary">Click me</button>
+```
+
+You can instead do
+
+```html
+<button id="myBtn">Click me</button>
+```
+```less
+@import "custom.bootstrap.variables.import.less";
+@import (reference) "custom.bootstrap.import.less";
+
+#myBtn {
+  &:extend(.btn, .btn-default);
+  background-color: @brand-primary;
+}
+```
+
+Some Bootstrap classes will require an additional `all` keyword when `extend`ing. For example:
+
+```html
+<input id="emailInput" placeholder="Enter your email">
+```
+```less
+@import (reference) "custom.bootstrap.import.less";
+
+input {
+  &:extend(.form-control all);
+}
+```
+This is because there are many pseudo-classes that `.form-control` has associated with it, but the standard `extend` only finds exact matches. To match those pseudo-classes as well, you need to use the `all` keyword.
+
+
+## License
 
 This package is licensed with the MIT license.
 Also, look at the [Bootstrap license](https://github.com/twbs/bootstrap/blob/v3.2.0/LICENSE).
 
-Origin
-------
+## Origin
 
 This package is based on and inspired by the [bootstrap3-less](https://github.com/simison/bootstrap3-less) package. I created a new repository because it takes a completely different approach now which is also incompatible.

--- a/bootstrap-configurator.js
+++ b/bootstrap-configurator.js
@@ -92,8 +92,7 @@ var handler = function (compileStep, isLiterate) {
   // file extensions
   var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.import.less')
   var variablesLessFile = jsonPath.replace(/json$/i, 'variables.import.less');
-  var outputLessFile = jsonPath.replace(/json$/i, 'import.less');
-  var outputCssFile = jsonPath.replace(/json$/i, 'css.import.less');
+  var outputCssFile = jsonPath.replace(/json$/i, 'import.less');
 
   createFile(mixinsLessFile, [
     "// THIS FILE IS GENERATED, DO NOT MODIFY IT!",
@@ -129,7 +128,6 @@ var handler = function (compileStep, isLiterate) {
 
   // Compile the created Less file into CSS
   var lessOptions = {
-    filename: outputLessFile,
     syncImport: true,
     paths: [path.dirname(compileStep._fullInputPath)] // for @import
   }

--- a/bootstrap-configurator.js
+++ b/bootstrap-configurator.js
@@ -4,7 +4,7 @@ var less = Npm.require('less');
 
 var createFile = function (path, content) {
   fs.writeFileSync(path, content.join('\n'), { encoding: 'utf8' });
-}
+};
 
 var getAsset = function (filename) {
   return BootstrapData(filename);
@@ -12,8 +12,8 @@ var getAsset = function (filename) {
 
 var getLessContent = function (filename) {
   var content = getAsset(filename);
-  return '\n\n// @import "' + filename + '"\n'
-    + content.replace(/@import\s*["']([^"]+)["'];?/g, function (statement, importFile) {
+  return '\n\n// @import "' + filename + '"\n' + 
+    content.replace(/@import\s*["']([^"]+)["'];?/g, function (statement, importFile) {
     return getLessContent(path.join(path.dirname(filename), importFile));
   });
 };
@@ -52,7 +52,7 @@ var handler = function (compileStep, isLiterate) {
   var allModulesOk = _.every(moduleConfiguration, function (enabled, module) {
     
     var moduleDefinition = moduleDefinitions[module];
-    if (moduleDefinition == null) {
+    if ( moduleDefinition === null ) {
       compileStep.error({
         message: "The module '" + module + "' does not exist.",
         sourcePath: compileStep.inputPath
@@ -90,7 +90,7 @@ var handler = function (compileStep, isLiterate) {
   }
   
   // file extensions
-  var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.less')
+  var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.less');
   var variablesLessFile = jsonPath.replace(/json$/i, 'variables.less');
   var outputCssFile = jsonPath.replace(/json$/i, 'less');
 
@@ -130,7 +130,7 @@ var handler = function (compileStep, isLiterate) {
   var lessOptions = {
     syncImport: true,
     paths: [path.dirname(compileStep._fullInputPath)] // for @import
-  }
+  };
 
   less.render(bootstrapLess, lessOptions, function(error, output) {
     if (error) {

--- a/bootstrap-configurator.js
+++ b/bootstrap-configurator.js
@@ -90,9 +90,9 @@ var handler = function (compileStep, isLiterate) {
   }
   
   // file extensions
-  var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.import.less')
-  var variablesLessFile = jsonPath.replace(/json$/i, 'variables.import.less');
-  var outputCssFile = jsonPath.replace(/json$/i, 'import.less');
+  var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.less')
+  var variablesLessFile = jsonPath.replace(/json$/i, 'variables.less');
+  var outputCssFile = jsonPath.replace(/json$/i, 'less');
 
   createFile(mixinsLessFile, [
     "// THIS FILE IS GENERATED, DO NOT MODIFY IT!",
@@ -135,8 +135,10 @@ var handler = function (compileStep, isLiterate) {
   less.render(bootstrapLess, lessOptions, function(error, output) {
     if (error) {
       compileStep.error({
-        message: "Error generating the Bootstrap css file, " + error,
-        sourcePath: compileStep.inputPath
+        message: "Error generating custom.bootstrap.less, " + error.message,
+        sourcePath: error.filename || compileStep.inputPath,
+        line: error.line,
+        column: error.column + 1
       });
     } else {
       createFile(outputCssFile, [
@@ -166,8 +168,3 @@ var handler = function (compileStep, isLiterate) {
 };
 
 Plugin.registerSourceHandler('bootstrap.json', {archMatching: 'web'}, handler);
-
-// Register the bootstrap variables as a dependency so that the css will be re-built
-Plugin.registerSourceHandler("bootstrap.variables.import.less", {archMatching: 'web'}, function () {
-  // Do nothing
-});

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: "semantic-bootstrap",
+  name: "grove:bootstrap",
   summary: "Highly configurable bootstrap integration.",
   version: "3.3.1_1",
   git: "https://github.com/grovelabs/meteor-bootstrap"

--- a/package.js
+++ b/package.js
@@ -1,12 +1,11 @@
 Package.describe({
-  name: "nemo64:bootstrap",
+  name: "semantic-bootstrap",
   summary: "Highly configurable bootstrap integration.",
   version: "3.3.1_1",
-  git: "https://github.com/Nemo64/meteor-bootstrap"
+  git: "https://github.com/grovelabs/meteor-bootstrap"
 });
 
-
-Package._transitional_registerBuildPlugin({
+Package.registerBuildPlugin({
   name: 'bootstrap-configurator',
   use: [
     'underscore@1.0.2',
@@ -20,12 +19,4 @@ Package._transitional_registerBuildPlugin({
   npmDependencies: {
     "less": "2.2.0"
   }
-});
-
-Package.on_use(function (api) {
-  api.versionsFrom("METEOR@0.9.2.2");
-  api.use([
-    'jquery',
-    'nemo64:bootstrap-data@3.3.1_1'
-  ], 'client');
 });

--- a/package.js
+++ b/package.js
@@ -17,7 +17,9 @@ Package._transitional_registerBuildPlugin({
     'distributed-configuration.js',
     'bootstrap-configurator.js'
   ],
-  npmDependencies: {}
+  npmDependencies: {
+    "less": "2.2.0"
+  }
 });
 
 Package.on_use(function (api) {


### PR DESCRIPTION
Instead of generating the Bootstrap Less file, the package now takes it one step further and generates the resulting Bootstrap CSS file. This is needed if you're trying to use Bootstrap in your stylesheets rather than the HTML (much cleaner and semantic in my opinion). Some of the file extensions are changed for clarity and so users can be more explicit about where the styles are being used.
