### PR TITLE
Allow setting all files to .import mode.

### DIFF
--- a/bootstrap-configurator.js
+++ b/bootstrap-configurator.js
@@ -91,7 +91,11 @@ var handler = function (compileStep, isLiterate) {
   // filenames
   var mixinsLessFile = jsonPath.replace(/json$/i, 'mixins.import.less')
   var importLessFile = jsonPath.replace(/json$/i, 'import.less');
-  var outputLessFile = jsonPath.replace(/json$/i, 'less');
+  if( userConfiguration.generateInclude ){
+    var outputLessFile = jsonPath.replace(/json$/i, 'modules.import.less');
+  }else{
+    var outputLessFile = jsonPath.replace(/json$/i, 'less');
+  }
 
   createLessFile(mixinsLessFile, [
     "// THIS FILE IS GENERATED, DO NOT MODIFY IT!",

--- a/distributed-configuration.js
+++ b/distributed-configuration.js
@@ -1,5 +1,7 @@
 distributedConfiguration = [
-  '{"modules": {',
+  '{"generateInclude":       false,',
+  ' "modules": ',
+  ' {',
   '  "normalize":            true,',
   '  "print":                false,',
   '',


### PR DESCRIPTION
Add option to allow custom.bootstrap.less to be generated as custom.bootstrap.modules.import.less instead.

The purpose of this is to allow other less files to extend item's in the modules file without duplicating css.

It would allow you to create a single styles.less file that imports all your .import.less files, control import order and avoids duplication.