### PR TITLE
Bump Bootstrap to 3.3.4

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: "nemo64:bootstrap",
   summary: "Highly configurable bootstrap integration.",
-  version: "3.3.1_1",
+  version: "3.3.4_1",
   git: "https://github.com/Nemo64/meteor-bootstrap"
 });
 
@@ -10,7 +10,7 @@ Package._transitional_registerBuildPlugin({
   name: 'bootstrap-configurator',
   use: [
     'underscore@1.0.2',
-    'nemo64:bootstrap-data@3.3.1_1'
+    'nemo64:bootstrap-data@3.3.4_1'
   ],
   sources: [
     'module-definitions.js',
@@ -24,6 +24,6 @@ Package.on_use(function (api) {
   api.versionsFrom("METEOR@0.9.2.2");
   api.use([
     'jquery',
-    'nemo64:bootstrap-data@3.3.1_1'
+    'nemo64:bootstrap-data@3.3.4_1'
   ], 'client');
 });


### PR DESCRIPTION
Also requires https://github.com/Nemo64/meteor-bootstrap-data/pull/3